### PR TITLE
Fix zeit routing

### DIFF
--- a/now.json
+++ b/now.json
@@ -8,8 +8,5 @@
       "config": { "distDir": "build" }
     }
   ],
-  "routes": [
-    { "src": "/static/(.*)", "dest": "app/static/$1" },
-    { "src": "/(.*)", "dest": "app/index.html" }
-  ]
+  "routes": [{ "src": "/(.*)", "dest": "app/index.html" }]
 }

--- a/now.json
+++ b/now.json
@@ -8,5 +8,8 @@
       "config": { "distDir": "build" }
     }
   ],
-  "routes": [{ "src": "/(.*)", "dest": "app/index.html" }]
+  "routes": [
+    { "src": "/static/(.*)", "dest": "app/static/$1" },
+    { "src": "/(.*)", "dest": "app/index.html" }
+  ]
 }

--- a/now.json
+++ b/now.json
@@ -8,8 +8,5 @@
       "config": { "distDir": "build" }
     }
   ],
-  "routes": [{ "src": "/(.*)", "dest": "app/$1" }],
-  "static": {
-    "rewrites": [{ "source": "**", "destination": "/index.html" }]
-  }
+  "routes": [{ "src": "/(.*)", "dest": "app/index.html" }]
 }

--- a/now.json
+++ b/now.json
@@ -8,5 +8,8 @@
       "config": { "distDir": "build" }
     }
   ],
-  "routes": [{ "src": "/(.*)", "dest": "app/$1" }]
+  "routes": [{ "src": "/(.*)", "dest": "app/$1" }],
+  "static": {
+    "rewrites": [{ "source": "**", "destination": "/index.html" }]
+  }
 }


### PR DESCRIPTION
Zeit routing wasn't working if you tried to navigate to anything other than the base URL. 

I had to update the routes object to: 
```
"routes": [
    { "src": "/static/(.*)", "dest": "app/static/$1" },
    { "src": "/(.*)", "dest": "app/index.html" }
  ]
```